### PR TITLE
feat: Add simple boilerplate for the integration testing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,13 @@
 use cli::handle_cli;
 
 mod actor;
-mod api;
-mod app;
+pub mod api;
+pub mod app;
 mod cli;
-mod error;
+pub mod error;
 mod logging;
-mod services;
-mod version;
+pub mod services;
+pub mod version;
 
 pub async fn cli() -> Result<(), Box<dyn std::error::Error>> {
     handle_cli().await?;

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct OperationService {}
 
 impl OperationService {

--- a/tests/api/root_controller_test.rs
+++ b/tests/api/root_controller_test.rs
@@ -1,81 +1,7 @@
-use std::net::SocketAddr;
 use netheril::{api::router, services::{OperationService, ServiceRegistry}, version::BUILD};
-use reqwest::RequestBuilder;
 use serde::Deserialize;
-use tokio::{task::JoinHandle};
-use axum::Router;
 
-#[derive(Debug)]
-struct Client {
-    addr: SocketAddr,
-    client: reqwest::Client,
-}
-
-impl Client {
-    fn new(addr: SocketAddr) -> Result<Self, Box<dyn std::error::Error>> {
-        let client = reqwest::Client::builder().build()?;
-        Ok(Self { addr, client })
-    }
-
-    fn get<R: Into<RelativeUrl>>(&self, path: R) -> RequestBuilder {
-        let url = self.base_url(path.into());
-        self.client.get(url)
-    }
-
-    fn base_url(&self, path: RelativeUrl) -> String {
-        format!("http://{}:{}{}", self.addr.ip(), self.addr.port(), path)
-    }
-}
-
-#[derive(Debug)]
-struct RelativeUrl(String);
-
-impl std::fmt::Display for RelativeUrl {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl From<&str> for RelativeUrl {
-    fn from(value: &str) -> Self {
-        const HTTP_PREFIX: &str = "http://";
-        const HTTPS_PREFIX: &str = "https://";
-
-        let candidate = value.to_lowercase();
-
-        if candidate.starts_with(HTTP_PREFIX) && candidate.starts_with(HTTPS_PREFIX) {
-            panic!("bad relative url: `{}`", value)
-        }
-
-	RelativeUrl(value.to_string())
-    }
-}
-
-#[derive(Debug)]
-struct TestServer {
-    server_handle: JoinHandle<()>,
-}
-
-impl TestServer {
-    async fn new(router: Router) -> Result<(Self, Client), Box<dyn std::error::Error>> {
-        const ANY_LOCAL_PORT: &str = "0.0.0.0:0";
-
-        let listener = tokio::net::TcpListener::bind(ANY_LOCAL_PORT).await?;
-        let addr = listener.local_addr()?;
-
-        let server_handle = tokio::spawn(async move {
-            axum::serve(listener, router).await.unwrap();
-        });
-
-        Ok((Self { server_handle }, Client::new(addr)?))
-    }
-}
-
-impl Drop for TestServer {
-    fn drop(&mut self) {
-        self.server_handle.abort()
-    }
-}
+use crate::common::api_server;
 
 #[tokio::test]
 async fn it_should_return_the_build_information() {
@@ -97,7 +23,7 @@ async fn it_should_return_the_build_information() {
     };
 
     let router = router().with_state(services);
-    let (_server, client) = TestServer::new(router).await.unwrap();
+    let (_server, client) = api_server(router).await;
 
     let response: Response = client
         .get("/api/")

--- a/tests/api/root_controller_test.rs
+++ b/tests/api/root_controller_test.rs
@@ -1,4 +1,8 @@
-use netheril::{api::router, services::{OperationService, ServiceRegistry}, version::BUILD};
+use netheril::{
+    api::router,
+    services::{OperationService, ServiceRegistry},
+    version::BUILD,
+};
 use serde::Deserialize;
 
 use crate::common::api_server;
@@ -7,9 +11,9 @@ use crate::common::api_server;
 async fn it_should_return_the_build_information() {
     #[derive(Deserialize)]
     struct BuildResponse {
-	version: String,
-	git_sha: String,
-	build_date: String,
+        version: String,
+        git_sha: String,
+        build_date: String,
     }
 
     #[derive(Deserialize)]
@@ -19,7 +23,7 @@ async fn it_should_return_the_build_information() {
     }
 
     let services = ServiceRegistry {
-	operation_service: OperationService::new(),
+        operation_service: OperationService::new(),
     };
 
     let router = router().with_state(services);

--- a/tests/api/root_controller_test.rs
+++ b/tests/api/root_controller_test.rs
@@ -1,5 +1,116 @@
-#[test]
-fn it_add_something() {
-    let x = 1 + 2;
-    assert_eq!(3, x)
+use std::net::SocketAddr;
+use netheril::{api::router, services::{OperationService, ServiceRegistry}, version::BUILD};
+use reqwest::RequestBuilder;
+use serde::Deserialize;
+use tokio::{task::JoinHandle};
+use axum::Router;
+
+#[derive(Debug)]
+struct Client {
+    addr: SocketAddr,
+    client: reqwest::Client,
+}
+
+impl Client {
+    fn new(addr: SocketAddr) -> Result<Self, Box<dyn std::error::Error>> {
+        let client = reqwest::Client::builder().build()?;
+        Ok(Self { addr, client })
+    }
+
+    fn get<R: Into<RelativeUrl>>(&self, path: R) -> RequestBuilder {
+        let url = self.base_url(path.into());
+        self.client.get(url)
+    }
+
+    fn base_url(&self, path: RelativeUrl) -> String {
+        format!("http://{}:{}{}", self.addr.ip(), self.addr.port(), path)
+    }
+}
+
+#[derive(Debug)]
+struct RelativeUrl(String);
+
+impl std::fmt::Display for RelativeUrl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<&str> for RelativeUrl {
+    fn from(value: &str) -> Self {
+        const HTTP_PREFIX: &str = "http://";
+        const HTTPS_PREFIX: &str = "https://";
+
+        let candidate = value.to_lowercase();
+
+        if candidate.starts_with(HTTP_PREFIX) && candidate.starts_with(HTTPS_PREFIX) {
+            panic!("bad relative url: `{}`", value)
+        }
+
+	RelativeUrl(value.to_string())
+    }
+}
+
+#[derive(Debug)]
+struct TestServer {
+    server_handle: JoinHandle<()>,
+}
+
+impl TestServer {
+    async fn new(router: Router) -> Result<(Self, Client), Box<dyn std::error::Error>> {
+        const ANY_LOCAL_PORT: &str = "0.0.0.0:0";
+
+        let listener = tokio::net::TcpListener::bind(ANY_LOCAL_PORT).await?;
+        let addr = listener.local_addr()?;
+
+        let server_handle = tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+
+        Ok((Self { server_handle }, Client::new(addr)?))
+    }
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        self.server_handle.abort()
+    }
+}
+
+#[tokio::test]
+async fn it_should_return_the_build_information() {
+    #[derive(Deserialize)]
+    struct BuildResponse {
+	version: String,
+	git_sha: String,
+	build_date: String,
+    }
+
+    #[derive(Deserialize)]
+    struct Response {
+        message: String,
+        build: BuildResponse,
+    }
+
+    let services = ServiceRegistry {
+	operation_service: OperationService::new(),
+    };
+
+    let router = router().with_state(services);
+    let (_server, client) = TestServer::new(router).await.unwrap();
+
+    let response: Response = client
+        .get("/api/")
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    assert_eq!(response.message, "Hello from Netheril");
+
+    assert_eq!(response.build.version, BUILD.version);
+    assert_eq!(response.build.git_sha, BUILD.git_sha);
+    assert_eq!(response.build.build_date, BUILD.build_date);
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,83 @@
+use std::net::SocketAddr;
+use reqwest::RequestBuilder;
+use tokio::{task::JoinHandle};
+use axum::Router;
+
+#[derive(Debug)]
+pub struct Client {
+    addr: SocketAddr,
+    client: reqwest::Client,
+}
+
+impl Client {
+    fn new(addr: SocketAddr) -> Result<Self, Box<dyn std::error::Error>> {
+        let client = reqwest::Client::builder().build()?;
+        Ok(Self { addr, client })
+    }
+
+    pub fn get<R: Into<RelativeUrl>>(&self, path: R) -> RequestBuilder {
+        let url = self.base_url(path.into());
+        self.client.get(url)
+    }
+
+    pub fn base_url(&self, path: RelativeUrl) -> String {
+        format!("http://{}:{}{}", self.addr.ip(), self.addr.port(), path)
+    }
+}
+
+#[derive(Debug)]
+pub struct RelativeUrl(String);
+
+impl std::fmt::Display for RelativeUrl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<&str> for RelativeUrl {
+    fn from(value: &str) -> Self {
+        const HTTP_PREFIX: &str = "http://";
+        const HTTPS_PREFIX: &str = "https://";
+
+        let candidate = value.to_lowercase();
+
+        if candidate.starts_with(HTTP_PREFIX) && candidate.starts_with(HTTPS_PREFIX) {
+            panic!("bad relative url: `{}`", value)
+        }
+
+	RelativeUrl(value.to_string())
+    }
+}
+
+#[derive(Debug)]
+pub struct TestServer {
+    server_handle: JoinHandle<()>,
+}
+
+
+impl TestServer {
+    async fn new(router: Router) -> Result<(Self, Client), Box<dyn std::error::Error>> {
+	const ANY_LOCAL_PORT: &str = "0.0.0.0:0";
+
+	let listener = tokio::net::TcpListener::bind(ANY_LOCAL_PORT).await?;
+	let addr = listener.local_addr()?;
+
+	let server_handle = tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+	});
+
+	Ok((Self { server_handle }, Client::new(addr)?))
+    }
+}
+
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        self.server_handle.abort()
+    }
+}
+
+pub async fn api_server(router: Router) -> (TestServer, Client) {
+    TestServer::new(router).await.expect("should create an api server ready for testing")
+}
+ 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,7 +1,7 @@
-use std::net::SocketAddr;
-use reqwest::RequestBuilder;
-use tokio::{task::JoinHandle};
 use axum::Router;
+use reqwest::RequestBuilder;
+use std::net::SocketAddr;
+use tokio::task::JoinHandle;
 
 #[derive(Debug)]
 pub struct Client {
@@ -45,7 +45,7 @@ impl From<&str> for RelativeUrl {
             panic!("bad relative url: `{}`", value)
         }
 
-	RelativeUrl(value.to_string())
+        RelativeUrl(value.to_string())
     }
 }
 
@@ -54,22 +54,20 @@ pub struct TestServer {
     server_handle: JoinHandle<()>,
 }
 
-
 impl TestServer {
     async fn new(router: Router) -> Result<(Self, Client), Box<dyn std::error::Error>> {
-	const ANY_LOCAL_PORT: &str = "0.0.0.0:0";
+        const ANY_LOCAL_PORT: &str = "0.0.0.0:0";
 
-	let listener = tokio::net::TcpListener::bind(ANY_LOCAL_PORT).await?;
-	let addr = listener.local_addr()?;
+        let listener = tokio::net::TcpListener::bind(ANY_LOCAL_PORT).await?;
+        let addr = listener.local_addr()?;
 
-	let server_handle = tokio::spawn(async move {
+        let server_handle = tokio::spawn(async move {
             axum::serve(listener, router).await.unwrap();
-	});
+        });
 
-	Ok((Self { server_handle }, Client::new(addr)?))
+        Ok((Self { server_handle }, Client::new(addr)?))
     }
 }
-
 
 impl Drop for TestServer {
     fn drop(&mut self) {
@@ -78,6 +76,7 @@ impl Drop for TestServer {
 }
 
 pub async fn api_server(router: Router) -> (TestServer, Client) {
-    TestServer::new(router).await.expect("should create an api server ready for testing")
+    TestServer::new(router)
+        .await
+        .expect("should create an api server ready for testing")
 }
- 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,7 +1,2 @@
 mod api;
-
-#[test]
-fn it_add_something() {
-    let x = 1 + 2;
-    assert_eq!(3, x)
-}
+mod common;


### PR DESCRIPTION
- Test the `/api` endpoint
- Add a `TestServer` that allow to use `reqwest` in the tests